### PR TITLE
Closed ScrollPercentage with ScrollPercentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ import ScrollPercentage from 'react-scroll-percentage'
   <h2>
     Plain children are always rendered. Use onChange to monitor state.
   </h2>
-</Observer>
+</ScrollPercentage>
 ```


### PR DESCRIPTION
The ScrollPercentage tag on the readme was closed with an Observer tag. This will add the corresponding closing tag.